### PR TITLE
Restore switch `--overwrite` to write over existing tables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ __Arguments__
 
 It is suitable for restoring large tables without needing to write to disk or use a large amount of memory. Use it on an AWS EC2 instance for best results and to minimise network latency, this should yield restore speeds of around 15min per GB.
 
+Use `--overwrite` if the table already exists. Otherwise it will attempt to generate table on the fly.
+
 Can be run as a command line script or as an npm module. 
 
 # Command line usage
@@ -174,15 +176,52 @@ Can be run as a command line script or as an npm module.
     -V, --version                     output the version number
     -s, --source [path]               Full S3 path to a JSON backup file (Required)
     -t, --table [name]                Name of the Dynamo Table to restore to (Required)
+    -o, --overwrite                   Table already exists, skip auto-create. Default is false.
     -c, --concurrency <requestcount>  Number of concurrent requests & dynamo capacity units. Defaults to 200.
     -pk, --partitionkey [columnname]  Name of Primary Partition Key. If not provided will try determine from backup.
     -sk, --sortkey [columnname]       Name of Secondary Sort Key. Ignored unless --partitionkey is provided.
     -rc, --readcapacity <units>       Read Units for new table (when finished). Default is 5.
-    -wc, --writecapacity <units>      Write Units for new table (when finished). Default is 5.
-    -sf, --stop-on-failure            Stop process when the same batch fails to restore 3 times. Defaults to false.
+    -wc, --writecapacity <units>      Write Units for new table (when finished). Default is --concurrency.
+    -sf, --stop-on-failure            Stop process when the same batch fails to restore multiple times. Defaults to false.
     --aws-key <key>                   AWS access key. Will use AWS_ACCESS_KEY_ID env var if --aws-key not set
     --aws-secret <secret>             AWS secret key. Will use AWS_SECRET_ACCESS_KEY env var if --aws-secret not set
     --aws-region <region>             AWS region. Will use AWS_DEFAULT_REGION env var if --aws-region not set
+```
+
+## Examples
+
+```
+
+    # Restore over existing table (cmd.exe).
+    > node ./bin/dynamo-restore-from-s3 -t acme-customers -s s3://my-backups/acme-customers.json --overwrite 
+
+    # Restore over existing table (shell).
+    $ ./bin/dynamo-restore-from-s3 -t acme-customers -s s3://my-backups/acme-customers.json --overwrite 
+
+    # Restore over existing table, 1000 concurrent requests. Stop if any batch fails 1000 times.
+    $ ./bin/dynamo-restore-from-s3 -t acme-customers -c 1000 -s s3://my-backups/acme-customers.json --overwrite -sf
+
+    # Restore over existing table, 1000 concurrent requests. When finished, set read capacity to 50 and write capacity to 10 (both needed).
+    $ ./bin/dynamo-restore-from-s3 -t acme-customers -c 1000 -s s3://my-backups/acme-customers.json --overwrite --readcapacity 50 --writecapacity 10
+
+    # Auto-generate table (determine PK from backup). 
+    $ ./bin/dynamo-restore-from-s3 -t acme-customers -s s3://my-backups/acme-customers.json
+
+    # Auto-generate table with partition and sort key.
+    $ ./bin/dynamo-restore-from-s3 -t acme-orders -s s3://my-backups/acme-orders.json -pk customerId -sk createDate 
+
+    # Auto-generate table, defined PK. Concurrency 2000 (~ 2GB backup).
+    $ ./bin/dynamo-restore-from-s3 -t acme-orders -pk orderId -c 2000 -s s3://my-backups/acme-orders.json 
+
+    # Auto-generate table. 2000 write units during restore. When finished set 50 write units and 100 write units (both needed).
+    $ ./bin/dynamo-restore-from-s3 -t acme-orders -c 2000 -s s3://my-backups/acme-orders.json --readcapacity 100 --writecapacity 50
+
+    # Auto-generate table. Concurrency 50 (10 MB backup or less).
+    $ ./bin/dynamo-restore-from-s3 -t acme-orders -c 50 -s s3://my-backups/acme-orders.json 
+
+    # Auto-generate table. Concurrency 50. Stop process if any batch fails 50 times.
+    $ ./bin/dynamo-restore-from-s3 -t acme-orders -c 50 -sf -s s3://my-backups/acme-orders.json 
+
 ```
 
 # npm module usage
@@ -195,10 +234,8 @@ var DynamoRestore = require('dynamo-backup-to-s3').Restore;
 var restore = new DynamoRestore({
     source: 's3://my-backups/DynamoDB-backup-2016-09-28-15-36-40/acme-customers-prod.json',
     table: 'acme-customers-dev',
+    overwrite: true,
     concurrency: 200, // for large restores use 1 unit per MB as a rule of thumb (ie 1000 for 1GB restore)
-    partitionkey: 'customerId',
-    readcapacity: 1,
-    writecapacity: 1,
     awsAccessKey: /* AWS access key */,
     awsSecretKey: /* AWS secret key */,
     awsRegion: /* AWS region */
@@ -228,11 +265,12 @@ restore.run(function() {
 ```
 var options = {
     source: /* path to json file in s3 bucket, should start with s3://bucketname/... */,
-    table: /* name of dynamo table, created on the fly, MUST NOT EXIST */,
+    table: /* name of dynamo table, will be created on the fly unless overwritten */,
+    overwrite: /* true/false if table already exits (defaults to false) */
     concurrency: /* number of concurrent requests (and dynamo write capacity units) */,
-    partitionkey: /* name of partition key column*/,
+    partitionkey: /* name of partition key column */,
     sortkey: /* name of secondary (sort) key column */ ,
-    readcapacity: /* number of read capacity units */,
+    readcapacity: /* number of read capacity units (when restore finishes) */,
     writecapacity: /* number of write capacity units (when restore finishes) */,
     stopOnFailure: /* true/false should a single failed batch stop the whole restore job? */,
     awsAccessKey: /* AWS access key */,

--- a/bin/dynamo-restore-from-s3
+++ b/bin/dynamo-restore-from-s3
@@ -9,11 +9,12 @@ program
     .usage('[options] -s "s3://mybucket/path/to/file.json" -t "new-dynamodb-table"')
     .option('-s, --source [path]', 'Full S3 path to a JSON backup file (Required)')
     .option('-t, --table [name]', 'Name of the Dynamo Table to restore to (Required)')
+    .option('-o, --overwrite', 'Table already exists, skip auto-create. Default is false.')
     .option('-c, --concurrency <requestcount>', 'Number of concurrent requests & dynamo capacity units. Defaults to 200.')
     .option('-pk, --partitionkey [columnname]', 'Name of Primary Partition Key. If not provided will try determine from backup.')
     .option('-sk, --sortkey [columnname]', 'Name of Secondary Sort Key. Ignored unless --partitionkey is provided.')
     .option('-rc, --readcapacity <units>', 'Read Units for new table (when finished). Default is 5.')
-    .option('-wc, --writecapacity <units>', 'Write Units for new table (when finished). Default is 5.')
+    .option('-wc, --writecapacity <units>', 'Write Units for new table (when finished). Default is --concurrency.')
     .option('-sf, --stop-on-failure', 'Stop process when the same batch fails to restore 3 times. Defaults to false.', true)
     .option('--aws-key <key>', 'AWS access key. Will use AWS_ACCESS_KEY_ID env var if --aws-key not set')
     .option('--aws-secret <secret>', 'AWS secret key. Will use AWS_SECRET_ACCESS_KEY env var if --aws-secret not set')
@@ -36,6 +37,7 @@ var dynamoRestore = new DynamoRestore({
     // Main settings
     source: program.source,
     table: program.table,
+    overwrite: !!program.overwrite,
     concurrency: program.concurrency,
     stopOnFailure: !!program.stopOnFailure,
     // New table properties
@@ -62,6 +64,10 @@ function translate(contentLength) {
 dynamoRestore.on('error', function(message) {
     console.log(message);
     process.exit(-1);
+});
+
+dynamoRestore.on('warning', function(message) {
+    console.log(message);
 });
 
 dynamoRestore.on('start-download', function(streamMeta) {

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -103,7 +103,7 @@ DynamoRestore.prototype._checkTableExists = function(error, data) {
     if (data.TableNames.indexOf(this.options.table) > -1) {
         // Table exists, should we overwrite it??
         if (this.options.overwrite) {
-            this.emit('warning', util.format('WARN: table [%s] will be overwritten.', options.table));
+            this.emit('warning', util.format('WARN: table [%s] will be overwritten.', this.options.table));
             dynamodb.describeTable({ TableName: this.options.table }, this._checkTableReady.bind(this));
         } else {
             this.emit('error', 'Fatal Error. The destination table already exists! Exiting process..');

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -106,7 +106,7 @@ DynamoRestore.prototype._checkTableExists = function(error, data) {
         // Table exists, should we overwrite it??
         if (this.options.overwrite) {
             this.emit('warning', util.format('WARN: table [%s] will be overwritten.', this.options.table));
-            setTimeout(dynamodb.describeTable.bind(dynamodb, { TableName: this.options.table }, this._checkTableReady.bind(this), 1000);
+            setTimeout(dynamodb.describeTable.bind(dynamodb, { TableName: this.options.table }, this._checkTableReady.bind(this)), 1000);
         } else {
             this.emit('error', 'Fatal Error. The destination table already exists! Exiting process..');
         }

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -98,6 +98,7 @@ DynamoRestore.prototype._validateTable = function(options) {
 };
 
 DynamoRestore.prototype._checkTableExists = function(error, data) {
+    var dynamodb = this.dynamodb;
     if (error || !data || !data.TableNames) {
         return this.emit('error', 'Fatal Error. Could not connect to AWS DynamoDB engine. Please check your credentials.');
     }
@@ -105,7 +106,7 @@ DynamoRestore.prototype._checkTableExists = function(error, data) {
         // Table exists, should we overwrite it??
         if (this.options.overwrite) {
             this.emit('warning', util.format('WARN: table [%s] will be overwritten.', this.options.table));
-            this.dynamodb.describeTable({ TableName: this.options.table }, this._checkTableReady.bind(this));
+            setTimeout(dynamodb.describeTable.bind(dynamodb, { TableName: this.options.table }, this._checkTableReady.bind(this), 1000);
         } else {
             this.emit('error', 'Fatal Error. The destination table already exists! Exiting process..');
         }

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -315,7 +315,7 @@ DynamoRestore.prototype._sendBatch = function() {
         var unprocessedItems = data && data.UnprocessedItems && data.UnprocessedItems[options.table] || [];
         if (unprocessedItems.length) {
             // Retry unprocessed items
-            this.emit('warning', 'Retrying ' + unprocessedItems.length + ' unprocessed items');
+            this.emit('warning', unprocessedItems.length + ' unprocessed items. Add to queue and back off a bit.');
             this.batches.push({
                 items: unprocessedItems,
                 attempts: batch.attempts + 1

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -19,7 +19,7 @@ function DynamoRestore(options) {
     options.minConcurrency = 1;
     options.maxConcurrency = options.concurrency;
     options.readcapacity = options.readcapacity || 5;
-    options.writecapacity = options.writecapacity || 5;
+    options.writecapacity = options.writecapacity || 0;
     options.stopOnFailure = options.stopOnFailure || false;
     options.awsKey = options.awsKey || process.env.AWS_ACCESS_KEY_ID;
     options.awsSecret = options.awsSecret || process.env.AWS_SECRET_ACCESS_KEY;
@@ -42,18 +42,6 @@ DynamoRestore.prototype.run = function(finishCallback) {
     this._validateS3Backup(this.options);
     this._validateTable(this.options);
     this._startDownload();
-    this.on('finish', (function() {
-        var dynamodb = new AWS.DynamoDB(),
-            options = this.options;
-        // Finish off by updating read/write capacity to end-state
-        dynamodb.updateTable({
-            TableName: options.table,
-            ProvisionedThroughput: {
-                ReadCapacityUnits: options.readcapacity,
-                WriteCapacityUnits: options.writecapacity
-            }
-        }, finishCallback);
-    }).bind(this));
     // Exit program by default if there are no error listeners attached.
     this.on('error', (function(message) {
         if (finishCallback) {
@@ -61,6 +49,23 @@ DynamoRestore.prototype.run = function(finishCallback) {
         }
         if (this.listeners('error').length <= 1) {
             throw new Error(message);
+        }
+    }).bind(this));
+    // Finish off by updating write capacity to end-state (if needed)
+    this.on('finish', (function() {
+        var dynamodb = new AWS.DynamoDB(),
+            options = this.options;
+        // Do we need to update write capacity?
+        if (options.writecapacity) {
+            dynamodb.updateTable({
+                TableName: options.table,
+                ProvisionedThroughput: {
+                    ReadCapacityUnits: options.readcapacity,
+                    WriteCapacityUnits: options.writecapacity
+                }
+            }, finishCallback);
+        } else {
+            finishCallback();
         }
     }).bind(this));
 };
@@ -96,7 +101,14 @@ DynamoRestore.prototype._checkTableExists = function(error, data) {
         return this.emit('error', 'Fatal Error. Could not connect to AWS DynamoDB engine. Please check your credentials.');
     }
     if (data.TableNames.indexOf(this.options.table) > -1) {
-        return this.emit('error', 'Fatal Error. The destination table already exists! Exiting process..');
+        // Table exists, should we overwrite it??
+        if (this.options.overwrite) {
+            this.emit('warning', util.format('WARN: table [%s] will be overwritten.', options.table));
+            dynamodb.describeTable({ TableName: this.options.table }, this._checkTableReady.bind(this));
+        } else {
+            this.emit('error', 'Fatal Error. The destination table already exists! Exiting process..');
+        }
+        return;
     }
     if (this.options.partitionkey && this.options.partitionkeytype) {
         // Once we know the partition key and data type the rest is a breeze.

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -32,6 +32,7 @@ function DynamoRestore(options) {
     });
 
     this.options = options;
+    this.dynamodb = new AWS.DynamoDB();
 }
 
 // Stick to prototypal inheritance. While this can be done differently 
@@ -53,7 +54,7 @@ DynamoRestore.prototype.run = function(finishCallback) {
     }).bind(this));
     // Finish off by updating write capacity to end-state (if needed)
     this.on('finish', (function() {
-        var dynamodb = new AWS.DynamoDB(),
+        var dynamodb = this.dynamodb,
             options = this.options;
         // Do we need to update write capacity?
         if (options.writecapacity) {
@@ -89,7 +90,7 @@ DynamoRestore.prototype._validateS3Backup = function(options) {
 };
 
 DynamoRestore.prototype._validateTable = function(options) {
-    var dynamodb = new AWS.DynamoDB();
+    var dynamodb = this.dynamodb;
     if (!options.table) {
         return this.emit('error', 'Please provide a Dynamo DB table name to restore to.');
     }
@@ -104,7 +105,7 @@ DynamoRestore.prototype._checkTableExists = function(error, data) {
         // Table exists, should we overwrite it??
         if (this.options.overwrite) {
             this.emit('warning', util.format('WARN: table [%s] will be overwritten.', this.options.table));
-            dynamodb.describeTable({ TableName: this.options.table }, this._checkTableReady.bind(this));
+            this.dynamodb.describeTable({ TableName: this.options.table }, this._checkTableReady.bind(this));
         } else {
             this.emit('error', 'Fatal Error. The destination table already exists! Exiting process..');
         }
@@ -228,7 +229,7 @@ DynamoRestore.prototype._extractSchema = function(template) {
 };
 
 DynamoRestore.prototype._createTable = function(callback) {
-    var dynamodb = new AWS.DynamoDB(),
+    var dynamodb = this.dynamodb,
         options = this.options;
     if (!options.table || !options.partitionkey) {
         return this.emit('error', 'Fatal Error. Could not create dynamo table. Not enough information provided.');
@@ -269,7 +270,7 @@ DynamoRestore.prototype._createTable = function(callback) {
 };
 
 DynamoRestore.prototype._checkTableReady = function(error, data) {
-    var dynamodb = new AWS.DynamoDB();
+    var dynamodb = this.dynamodb;
     if (error || !data || !data.Table) {
         return this.emit('error', 'Error creating table ' + this.options.table);
     }
@@ -288,7 +289,7 @@ DynamoRestore.prototype._checkTableReady = function(error, data) {
 DynamoRestore.prototype._sendBatch = function() {
     // Prepare
     var params = { RequestItems: {} },
-        dynamo = new AWS.DynamoDB(),
+        dynamo = this.dynamodb,
         options = this.options;
     batch = this.batches.shift();
     params.RequestItems[options.table] = batch.items;


### PR DESCRIPTION
As suggested by @kkozmic-seek. Would be good to have an `--overwrite` flag that allows restore process to write over existing tables. This allows more control over timing and table creation, and may be preferred in many circumstances where table schema has been defined by preexisting CLI script and/or cloudformation.